### PR TITLE
Add color palette selection and enhance UI styles

### DIFF
--- a/turbacz/static/rcm.html
+++ b/turbacz/static/rcm.html
@@ -174,6 +174,19 @@
         <div class="modal-content settings-modal-content">
             <div class="modal-header">RCM Settings</div>
             <div class="settings-list">
+                <div class="setting-row setting-row-select">
+                    <div class="setting-copy">
+                        <span class="setting-title">Color Palette</span>
+                        <span class="setting-description">Choose a visual theme for the RCM workspace.</span>
+                    </div>
+                    <select id="settingsColorPalette" class="setting-select">
+                        <option value="midnight">Midnight (Default)</option>
+                        <option value="forest">Forest</option>
+                        <option value="amber">Amber</option>
+                        <option value="arctic">Arctic</option>
+                    </select>
+                </div>
+
                 <label class="setting-row" for="settingsShowAutoOffControls">
                     <div class="setting-copy">
                         <span class="setting-title">Show Delay Sliders</span>

--- a/turbacz/static/scripts/rcm.js
+++ b/turbacz/static/scripts/rcm.js
@@ -49,7 +49,9 @@ if (isFirefox) {
 }
 
 const SETTINGS_STORAGE_KEY = 'rcm_settings'
+const AVAILABLE_COLOR_PALETTES = ['midnight', 'forest', 'amber', 'arctic']
 const DEFAULT_SETTINGS = {
+    colorPalette: 'midnight',
     showAutoOffControls: false,
     persistHiddenDevicesOnReload: false,
     showDeviceMetrics: true,
@@ -67,7 +69,17 @@ function loadSettings() {
 
     try {
         const parsed = JSON.parse(raw)
-        return { ...DEFAULT_SETTINGS, ...parsed }
+        const merged = { ...DEFAULT_SETTINGS, ...parsed }
+
+        // Backward compatibility with older palette key.
+        if (merged.colorPalette === 'ember') {
+            merged.colorPalette = 'amber'
+        }
+
+        if (!AVAILABLE_COLOR_PALETTES.includes(merged.colorPalette)) {
+            merged.colorPalette = DEFAULT_SETTINGS.colorPalette
+        }
+        return merged
     } catch (error) {
         console.warn('Failed to parse RCM settings, using defaults', error)
         return { ...DEFAULT_SETTINGS }
@@ -81,11 +93,24 @@ function saveSettings() {
 }
 
 function applySettingsToUI() {
+    const palette = AVAILABLE_COLOR_PALETTES.includes(appSettings.colorPalette)
+        ? appSettings.colorPalette
+        : DEFAULT_SETTINGS.colorPalette
+    document.body.setAttribute('data-color-palette', palette)
+
     document.body.classList.toggle('hide-auto-off-controls', !appSettings.showAutoOffControls)
     document.body.classList.toggle('hide-device-metrics', !appSettings.showDeviceMetrics)
 }
 
 function syncSettingsForm() {
+    const paletteField = document.getElementById('settingsColorPalette')
+    if (paletteField) {
+        const palette = AVAILABLE_COLOR_PALETTES.includes(appSettings.colorPalette)
+            ? appSettings.colorPalette
+            : DEFAULT_SETTINGS.colorPalette
+        paletteField.value = palette
+    }
+
     const fields = {
         settingsShowAutoOffControls: appSettings.showAutoOffControls,
         settingsPersistHiddenDevicesOnReload: appSettings.persistHiddenDevicesOnReload,
@@ -128,7 +153,13 @@ function saveSettingsFromModal() {
         return element ? element.checked : false
     }
 
+    const selectedPaletteField = document.getElementById('settingsColorPalette')
+    const selectedPalette = selectedPaletteField ? selectedPaletteField.value : DEFAULT_SETTINGS.colorPalette
+
     appSettings = {
+        colorPalette: AVAILABLE_COLOR_PALETTES.includes(selectedPalette)
+            ? selectedPalette
+            : DEFAULT_SETTINGS.colorPalette,
         showAutoOffControls: getChecked('settingsShowAutoOffControls'),
         persistHiddenDevicesOnReload: getChecked('settingsPersistHiddenDevicesOnReload'),
         showDeviceMetrics: getChecked('settingsShowDeviceMetrics'),

--- a/turbacz/static/styles/rcm.css
+++ b/turbacz/static/styles/rcm.css
@@ -62,29 +62,29 @@ body[data-color-palette="forest"] {
 
 body[data-color-palette="amber"],
 body[data-color-palette="ember"] {
-    --primary-color: #f6b84a;
-    --primary-dark: #db9220;
-    --primary-light: #ffe29a;
-    --secondary-color: #ff8a3d;
-    --success-color: #29c08a;
+    --primary-color: #c8a05e;
+    --primary-dark: #9a7742;
+    --primary-light: #e5cda0;
+    --secondary-color: #b78b54;
+    --success-color: #5ca58a;
     --danger-color: #f43f5e;
     --warning-color: #f59e0b;
-    --bg-primary: #1a1511;
-    --bg-secondary: #25201a;
-    --bg-tertiary: #352b21;
-    --text-primary: #fff7ea;
-    --text-secondary: #f8e3c0;
-    --text-muted: #d9ba83;
-    --border-color: #7f5d32;
-    --header-bg: rgba(37, 32, 26, 0.86);
-    --toolbar-group-bg: rgba(26, 21, 17, 0.52);
-    --toolbar-group-border: rgba(146, 109, 59, 0.6);
-    --zoom-controls-bg: rgba(37, 32, 26, 0.94);
-    --canvas-bg: rgba(37, 32, 26, 0.62);
-    --canvas-dot: rgba(255, 205, 118, 0.16);
-    --modal-overlay-bg: rgba(14, 11, 8, 0.84);
-    --settings-row-bg: rgba(26, 21, 17, 0.56);
-    --settings-row-border: rgba(216, 158, 76, 0.36);
+    --bg-primary: #161412;
+    --bg-secondary: #201d1a;
+    --bg-tertiary: #2d2721;
+    --text-primary: #f4efe6;
+    --text-secondary: #ddd3c1;
+    --text-muted: #b8aa94;
+    --border-color: #5b4e3d;
+    --header-bg: rgba(32, 29, 26, 0.88);
+    --toolbar-group-bg: rgba(22, 20, 18, 0.54);
+    --toolbar-group-border: rgba(108, 92, 70, 0.58);
+    --zoom-controls-bg: rgba(32, 29, 26, 0.94);
+    --canvas-bg: rgba(32, 29, 26, 0.64);
+    --canvas-dot: rgba(197, 170, 124, 0.12);
+    --modal-overlay-bg: rgba(12, 11, 10, 0.85);
+    --settings-row-bg: rgba(22, 20, 18, 0.57);
+    --settings-row-border: rgba(149, 123, 82, 0.32);
 }
 
 body[data-color-palette="arctic"] {

--- a/turbacz/static/styles/rcm.css
+++ b/turbacz/static/styles/rcm.css
@@ -23,6 +23,94 @@
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
     --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1);
+    --header-bg: rgba(30, 41, 59, 0.8);
+    --toolbar-group-bg: rgba(15, 23, 42, 0.4);
+    --toolbar-group-border: rgba(51, 65, 85, 0.5);
+    --zoom-controls-bg: rgba(30, 41, 59, 0.9);
+    --canvas-bg: rgba(30, 41, 59, 0.5);
+    --canvas-dot: rgba(148, 163, 184, 0.15);
+    --modal-overlay-bg: rgba(15, 23, 42, 0.75);
+    --settings-row-bg: rgba(15, 23, 42, 0.45);
+    --settings-row-border: rgba(100, 116, 139, 0.35);
+}
+
+body[data-color-palette="forest"] {
+    --primary-color: #3fbf8f;
+    --primary-dark: #2d8f6b;
+    --primary-light: #8de6c5;
+    --secondary-color: #d3a24e;
+    --success-color: #40c79a;
+    --danger-color: #ef4444;
+    --warning-color: #f59e0b;
+    --bg-primary: #0d1b1a;
+    --bg-secondary: #162a28;
+    --bg-tertiary: #21403b;
+    --text-primary: #edf8f4;
+    --text-secondary: #cce8dd;
+    --text-muted: #97c5b3;
+    --border-color: #2f5a53;
+    --header-bg: rgba(22, 42, 40, 0.84);
+    --toolbar-group-bg: rgba(13, 27, 26, 0.48);
+    --toolbar-group-border: rgba(63, 112, 102, 0.58);
+    --zoom-controls-bg: rgba(22, 42, 40, 0.93);
+    --canvas-bg: rgba(22, 42, 40, 0.57);
+    --canvas-dot: rgba(141, 230, 197, 0.13);
+    --modal-overlay-bg: rgba(8, 19, 18, 0.8);
+    --settings-row-bg: rgba(13, 27, 26, 0.52);
+    --settings-row-border: rgba(97, 177, 153, 0.32);
+}
+
+body[data-color-palette="amber"],
+body[data-color-palette="ember"] {
+    --primary-color: #f6b84a;
+    --primary-dark: #db9220;
+    --primary-light: #ffe29a;
+    --secondary-color: #ff8a3d;
+    --success-color: #29c08a;
+    --danger-color: #f43f5e;
+    --warning-color: #f59e0b;
+    --bg-primary: #1a1511;
+    --bg-secondary: #25201a;
+    --bg-tertiary: #352b21;
+    --text-primary: #fff7ea;
+    --text-secondary: #f8e3c0;
+    --text-muted: #d9ba83;
+    --border-color: #7f5d32;
+    --header-bg: rgba(37, 32, 26, 0.86);
+    --toolbar-group-bg: rgba(26, 21, 17, 0.52);
+    --toolbar-group-border: rgba(146, 109, 59, 0.6);
+    --zoom-controls-bg: rgba(37, 32, 26, 0.94);
+    --canvas-bg: rgba(37, 32, 26, 0.62);
+    --canvas-dot: rgba(255, 205, 118, 0.16);
+    --modal-overlay-bg: rgba(14, 11, 8, 0.84);
+    --settings-row-bg: rgba(26, 21, 17, 0.56);
+    --settings-row-border: rgba(216, 158, 76, 0.36);
+}
+
+body[data-color-palette="arctic"] {
+    --primary-color: #0ea5e9;
+    --primary-dark: #0369a1;
+    --primary-light: #67e8f9;
+    --secondary-color: #06b6d4;
+    --success-color: #14b8a6;
+    --danger-color: #ef4444;
+    --warning-color: #f59e0b;
+    --bg-primary: #0b1320;
+    --bg-secondary: #122136;
+    --bg-tertiary: #1d334d;
+    --text-primary: #f0f9ff;
+    --text-secondary: #bae6fd;
+    --text-muted: #7dd3fc;
+    --border-color: #1e3a5f;
+    --header-bg: rgba(18, 33, 54, 0.82);
+    --toolbar-group-bg: rgba(11, 19, 32, 0.48);
+    --toolbar-group-border: rgba(30, 58, 95, 0.6);
+    --zoom-controls-bg: rgba(18, 33, 54, 0.92);
+    --canvas-bg: rgba(18, 33, 54, 0.55);
+    --canvas-dot: rgba(125, 211, 252, 0.15);
+    --modal-overlay-bg: rgba(6, 13, 24, 0.8);
+    --settings-row-bg: rgba(11, 19, 32, 0.5);
+    --settings-row-border: rgba(14, 165, 233, 0.35);
 }
 
 /* Firefox Performance Optimizations */
@@ -30,12 +118,12 @@
 .firefox .device-box,
 .firefox .modal {
     backdrop-filter: none;
-    background: rgba(30, 41, 59, 0.98);
+    background: var(--zoom-controls-bg);
 }
 
 /* Reduce complexity on Firefox */
 .firefox .device-box {
-    background: rgba(30, 41, 59, 0.98);
+    background: var(--zoom-controls-bg);
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
 }
 
@@ -54,7 +142,7 @@ body {
 
 /* Header */
 .header {
-    background: rgba(30, 41, 59, 0.8);
+    background: var(--header-bg);
     backdrop-filter: blur(10px);
     border-bottom: 1px solid var(--border-color);
     padding: 0.75rem 1rem;
@@ -113,10 +201,10 @@ body {
     display: flex;
     gap: 0.375rem;
     align-items: center;
-    background: rgba(15, 23, 42, 0.4);
+    background: var(--toolbar-group-bg);
     padding: 0.25rem;
     border-radius: 8px;
-    border: 1px solid rgba(51, 65, 85, 0.5);
+    border: 1px solid var(--toolbar-group-border);
 }
 
 .toolbar-btn {
@@ -292,7 +380,7 @@ body {
     display: flex;
     gap: 0.375rem;
     align-items: center;
-    background: rgba(30, 41, 59, 0.9);
+    background: var(--zoom-controls-bg);
     padding: 0.5rem 0.625rem;
     border-radius: 8px;
     border: 1px solid var(--border-color);
@@ -352,12 +440,12 @@ body {
 }
 
 #canvas {
-    background: rgba(30, 41, 59, 0.5);
+    background: var(--canvas-bg);
     min-width: 50000px;
     min-height: 50000px;
     position: relative;
     background-image:
-        radial-gradient(circle at 1px 1px, rgba(148, 163, 184, 0.15) 1px, transparent 0);
+        radial-gradient(circle at 1px 1px, var(--canvas-dot) 1px, transparent 0);
     background-size: 30px 30px;
     transform-origin: 0 0;
 }
@@ -772,7 +860,7 @@ body.hide-device-metrics .signal-icon {
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(15, 23, 42, 0.75);
+    background: var(--modal-overlay-bg);
     backdrop-filter: blur(8px);
     z-index: 2000;
     justify-content: center;
@@ -930,10 +1018,33 @@ body.hide-device-metrics .signal-icon {
     align-items: flex-start;
     gap: 1rem;
     padding: 0.8rem 0.9rem;
-    background: rgba(15, 23, 42, 0.45);
-    border: 1px solid rgba(100, 116, 139, 0.35);
+    background: var(--settings-row-bg);
+    border: 1px solid var(--settings-row-border);
     border-radius: 10px;
     cursor: pointer;
+}
+
+.setting-row-select {
+    cursor: default;
+    align-items: center;
+}
+
+.setting-select {
+    min-width: 220px;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.55);
+    color: var(--text-primary);
+    font-size: 0.86rem;
+    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+}
+
+.setting-select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
 }
 
 .setting-copy {
@@ -1151,6 +1262,16 @@ body.hide-device-metrics .signal-icon {
 
     .settings-modal-content {
         min-width: 90%;
+    }
+
+    .setting-row-select {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .setting-select {
+        min-width: 0;
+        width: 100%;
     }
 
     .zoom-controls {

--- a/turbacz/turbacz/main.py
+++ b/turbacz/turbacz/main.py
@@ -258,7 +258,7 @@ async def upload_firmware(
 
 
 class BlindRequest(BaseModel):
-    blind: str = Field(pattern=r"^b[0-9]+$")
+    blind: str = Field(pattern=r"^r[0-9]+$")
     position: int = Field(ge=0, le=999)
 
 


### PR DESCRIPTION
This pull request adds support for user-selectable color palettes (themes) to the RCM UI, allowing users to choose between "Midnight", "Forest", "Amber", and "Arctic" visual themes. It introduces a new settings option in the UI, updates the CSS to support palette switching via CSS variables, and ensures backward compatibility with previous palette keys. Additionally, it fixes a validation pattern for blind IDs in the backend.

**Theme selection and palette support:**

* Added a "Color Palette" dropdown to the RCM settings modal in `rcm.html`, letting users choose the UI theme.
* Updated `rcm.js` to handle palette selection, persistence, and backward compatibility (e.g., mapping old "ember" to "amber"), and to apply the palette to the UI dynamically. [[1]](diffhunk://#diff-57509532fbf365aca8681e76d3c4610e5efdc0b1ba2911acfafe439b0bbdab42R52-R54) [[2]](diffhunk://#diff-57509532fbf365aca8681e76d3c4610e5efdc0b1ba2911acfafe439b0bbdab42L70-R82) [[3]](diffhunk://#diff-57509532fbf365aca8681e76d3c4610e5efdc0b1ba2911acfafe439b0bbdab42R96-R113) [[4]](diffhunk://#diff-57509532fbf365aca8681e76d3c4610e5efdc0b1ba2911acfafe439b0bbdab42R156-R162)

**CSS and visual updates:**

* Defined CSS variables for each color palette and updated the styles to use these variables, enabling dynamic theme switching. Added new classes for the palette selector and ensured responsive design. [[1]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071R26-R126) [[2]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L57-R145) [[3]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L116-R207) [[4]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L295-R383) [[5]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L355-R448) [[6]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L775-R863) [[7]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071L933-R1049) [[8]](diffhunk://#diff-8538f64e1021adf512f634edaf851af182a721af231683bbe0a8f8be3edf9071R1267-R1276)

**Backend validation fix:**

* Changed the regex pattern for the `blind` field in `BlindRequest` to require IDs starting with "r" instead of "b".